### PR TITLE
Relative probability metric

### DIFF
--- a/zone_model/evaluate.py
+++ b/zone_model/evaluate.py
@@ -39,4 +39,3 @@ for model_name, model in location_choice_models.items():
     relative_probabilities = pd.Series(model.relative_probabilities())
     print("  Variables by probability influence:")
     print(relative_probabilities.sort_values(ascending=False))
-    

--- a/zone_model/utils.py
+++ b/zone_model/utils.py
@@ -469,9 +469,9 @@ class SimulationChoiceModel(MNLDiscreteChoiceModel):
         if choosers is None or alternatives is None:
             choosers, alternatives = self.calculate_model_variables()
 
-        alternatives_plus = alternatives.append(alternative_data, 
+        alternatives_plus = alternatives.append(alternative_data,
                                                 ignore_index=True)
-        probabilities = self.calculate_probabilities(choosers, 
+        probabilities = self.calculate_probabilities(choosers,
                                                      alternatives_plus)
 
         probability = probabilities.iloc[-1]
@@ -481,9 +481,9 @@ class SimulationChoiceModel(MNLDiscreteChoiceModel):
     def relative_probabilities(self, low_percentile=.05, high_percentile=.95,
                                choosers=None, alternatives=None):
         """
-        Indicator of explanatory variable influence.  For each variable, 
-        calculate relative variable probability contribution by holding all 
-        other variables at their median value and having the variable of 
+        Indicator of explanatory variable influence.  For each variable,
+        calculate relative variable probability contribution by holding all
+        other variables at their median value and having the variable of
         interest take on its 5th and 95th percentile values, then calculating
         the difference in resulting probabilities.
         Parameters
@@ -501,7 +501,7 @@ class SimulationChoiceModel(MNLDiscreteChoiceModel):
         Returns
         -------
         relative_probabilities : dict
-            Mapping between variable name and it's contribution to 
+            Mapping between variable name and it's contribution to
             probability.
         """
         if choosers is None or alternatives is None:
@@ -524,16 +524,16 @@ class SimulationChoiceModel(MNLDiscreteChoiceModel):
             mock_observation = alternatives[constant_vars].median()
 
             mock_observation[var_to_measure] = high_percentile_value
-            high_proba = self.single_alternative_proba(mock_observation, 
+            high_proba = self.single_alternative_proba(mock_observation,
                                                        choosers, alternatives)
 
             mock_observation[var_to_measure] = low_percentile_value
-            low_proba = self.single_alternative_proba(mock_observation, 
+            low_proba = self.single_alternative_proba(mock_observation,
                                                       choosers, alternatives)
 
             proba_difference = high_proba - low_proba
             relative_probabilities[var_to_measure] = proba_difference
-            
+
         return relative_probabilities
 
 


### PR DESCRIPTION
Calculations for relative probability plots, to assist with assessing the influence of explanatory variables in a model specification.  E.g. With all other explanatory variables held at their median value, assess the probability of an alternative with a variable interest at its 5th perentile value and 95th percentile value, and then use the delta in probability as a measure of variable influence. 

Added as a SimulationChoiceModel method, so that the relative probabilities can be calculated for any model.  Also added a method for calculating probability of a single alternative (given existing alternatives) with user-speficied characteristics.  These methods could also be framed in terms of utilities rather than probabilities, e.g. for relative utility plots, but utilities are not currently easily exposed.

![relative_probability](https://cloud.githubusercontent.com/assets/2517961/25106310/9d6137f4-237d-11e7-986c-20c4a214e5f3.png)
