### PR TITLE
Paris model

### DIFF
--- a/zone_model/utils.py
+++ b/zone_model/utils.py
@@ -431,7 +431,6 @@ class SimulationChoiceModel(MNLDiscreteChoiceModel):
             for table in mt:
                 all_cols.extend(orca.get_table(table).columns)
             all_cols = [col for col in all_cols if col in self.columns_used()]
-            mt.append(self.alternatives)
             alternatives = orca.merge_tables(target=self.alternatives,
                                tables=mt, columns=all_cols)
         else:


### PR DESCRIPTION
Allow use of broadcasts to merge additional tables into the alternative set in SimulationChoiceModel. For use with models that make use of more traditional variable specifications (i.e. auto-generated variable sets don't require this because all variables are aggregated/disaggregated to the alternatives table already).