### PR TITLE
Cleanup and support for Scikit-learn v0.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,22 @@
 language: python
-sudo: false
+
 python:
-- '2.7'
-- '3.5'
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
 
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas pytest matplotlib scipy statsmodels pyyaml pycodestyle scikit-learn
-- source activate test-environment
-- conda list
-- pip install orca urbansim
-- cd .. && git clone https://github.com/udst/variable_generators.git
-- cd variable_generators && pip install .
-- cd $TRAVIS_BUILD_DIR && pip install .
-- cd zone_model/data && curl -O https://storage.googleapis.com/urbansim/zone_model/model_data.h5
-- cd $TRAVIS_BUILD_DIR/zone_model
+  - pip install .
+  - cd ..
+  - git clone https://github.com/udst/variable_generators.git
+  - cd variable_generators
+  - pip install .
+  - cd ../zone_model/zone_model/data
+  - curl -O https://storage.googleapis.com/urbansim/zone_model/model_data.h5
+  - cd ..
 
 script:
-- pycodestyle .
 - python simulate.py
 # - python evaluate.py # Commenting out for now as interaction terms warrant a revisit of evaluate

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas pytest matplotlib scipy statsmodels pyyaml pycodestyle scikit-learn
 - source activate test-environment
 - conda list
-- pip install .
+- pip install orca urbansim
 - cd .. && git clone git@github.com:urbansim/variable_generators.git
 - cd variable_generators && pip install .
 - cd $TRAVIS_BUILD_DIR && pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas pytest matplotlib scipy statsmodels pyyaml pycodestyle scikit-learn
 - source activate test-environment
 - conda list
-- pip install orca urbansim
+- pip install .
 - cd .. && git clone git@github.com:urbansim/variable_generators.git
 - cd variable_generators && pip install .
 - cd $TRAVIS_BUILD_DIR && pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 - source activate test-environment
 - conda list
 - pip install orca urbansim
-- cd .. && git clone git@github.com:urbansim/variable_generators.git
+- cd .. && git clone https://github.com/udst/variable_generators.git
 - cd variable_generators && pip install .
 - cd $TRAVIS_BUILD_DIR && pip install .
 - cd zone_model/data && curl -O https://storage.googleapis.com/urbansim/zone_model/model_data.h5

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
-# Install setuptools if not installed.
-try:
-    import setuptools
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-
 from setuptools import setup, find_packages
 
 
@@ -31,10 +24,13 @@ setup(
     ],
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
+        # Also requires 'variable_generators', not available on pypi:
+        # https://github.com/udst/variable_generators
         'joblib',
         'numpy >= 1.1.0',
         'orca >= 1.3.0',
         'pandas >= 0.16.0',
+        'patsy',
         'pyyaml',
         'urbansim >= 0.1.1',
         'scikit-learn >= 0.15.0'

--- a/setup.py
+++ b/setup.py
@@ -24,16 +24,19 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
+        'joblib',
         'numpy >= 1.1.0',
-        'pandas >= 0.16.0',
         'orca >= 1.3.0',
-        'urbansim >= 0.1.1',
+        'pandas >= 0.16.0',
         'pyyaml',
+        'urbansim >= 0.1.1',
         'scikit-learn >= 0.15.0'
     ]
 )

--- a/zone_model/utils.py
+++ b/zone_model/utils.py
@@ -6,9 +6,13 @@ import yaml
 import numpy as np
 import pandas as pd
 from patsy import dmatrix
-from sklearn.externals import joblib
 from sklearn.metrics import accuracy_score, r2_score
 from sklearn.model_selection import train_test_split
+
+try:
+    import joblib
+except ModuleNotFoundError as e:
+    from sklearn.externals import joblib  # deprecated in sklearn 0.23
 
 import orca
 from urbansim.utils import misc


### PR DESCRIPTION
This PR includes the following:
- updates the `joblib` import in `utils.py` to use either Scikit-learn (old behavior) or Joblib directly, depending on which is available (the Scikit-learn import was deprecated in v0.23) - issue #30 
- updates Travis tests to run in Python 2.7, 3.5, 3.6, 3.7, 3.8
- cleans up Travis script to install `zone_model` using `setup.py` directly - issue #20 
- some additional cleanup in `setup.py`

No substantive changes to any code. Travis tests are passing.

Does this look good? @janowicz @msoltadeo @jessicacamacho @cvanoli 